### PR TITLE
add dotenv support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ With Travis Encrypt installed, the command line application can be invoked with 
         --deploy                Encrypt a password for continuous deployment usage
         --env                   Encrypt an environment variable
         --clipboard             copy the encrypted password to the clipboard
+        --env-file PATH         Path for a .env file containing variables to encrypt
 
 When the command is entered, the application will issue a prompt where the user can enter
 either a password or environment variable. In both cases, the prompt will print 'Password:'.
@@ -69,6 +70,11 @@ Example of encrypting the environment variable API_TOKEN="abc123"::
     $  travis-encrypt --env mandeep Travis-Encrypt /home/user/.travis.yml
     Password:
     Encrypted password added to /home/user/.travis.yml
+
+Example of using a .env file::
+
+    $  travis-encrypt --env-file /home/user/my.env mandeep Travis-Encrypt /home/user/.travis.yml
+    Encrypted variables from /home/user/my.env added to /home/user/.travis.yml
 
 .. |travis| image:: https://img.shields.io/travis/mandeep/Travis-Encrypt/master.svg?style=flat-square
     :target: https://travis-ci.org/mandeep/Travis-Encrypt

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(name='travis-encrypt',
           'cryptography>=2.3',
           'PyYAML>=3.12',
           'requests>=2.19.1',
-          'pyperclip==1.6.0'
+          'pyperclip==1.6.0',
+          'python-dotenv>=0.9.1'
       ],
       entry_points='''
           [console_scripts]

--- a/travis/cli.py
+++ b/travis/cli.py
@@ -5,21 +5,52 @@ It imports functions found in Travis Encrypt's module in order to
 create the CLI.
 """
 import click
+from dotenv import dotenv_values
 import pyperclip
 
 from travis.encrypt import (retrieve_public_key, encrypt_key,
                             load_travis_configuration, dump_travis_configuration)
 
 
+class NotRequiredIf(click.Option):
+    """
+    Make option not required if another option is present
+    https://stackoverflow.com/a/44349292/5747944
+    """
+    def __init__(self, *args, **kwargs):
+        self.not_required_if = kwargs.pop('not_required_if')
+        assert self.not_required_if, "'not_required_if' parameter required"
+        kwargs['help'] = (kwargs.get('help', '') +
+            ' NOTE: This argument is mutually exclusive with %s' %
+            self.not_required_if
+        ).strip()
+        super(NotRequiredIf, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        we_are_present = self.name in opts
+        other_present = self.not_required_if in opts
+
+        if other_present:
+            if we_are_present:
+                raise click.UsageError(
+                    "Illegal usage: `%s` is mutually exclusive with `%s`" % (
+                        self.name, self.not_required_if))
+            else:
+                self.prompt = None
+
+        return super(NotRequiredIf, self).handle_parse_result(
+            ctx, opts, args)
+
 @click.command()
 @click.argument('username')
 @click.argument('repository')
 @click.argument('path', type=click.Path(exists=True), required=False)
-@click.option('--password', prompt=True, hide_input=True, confirmation_prompt=False, help="The password to be encrypted.")
+@click.option('--password', cls=NotRequiredIf, not_required_if='env_file', prompt=True, hide_input=True, confirmation_prompt=False, help="The password to be encrypted.")
 @click.option('--deploy', is_flag=True, help="Write to .travis.yml for deployment.")
 @click.option('--env', is_flag=True, help="Write to .travis.yml for environment variable use.")
 @click.option('--clipboard', is_flag=True, help="Copy the encrypted password to the clipboard")
-def cli(username, repository, path, password, deploy, env, clipboard):
+@click.option('--env-file', type=click.Path(exists=True))
+def cli(username, repository, path, password, deploy, env, clipboard, env_file):
     """Encrypt passwords and environment variables for use with Travis CI.
 
     Travis Encrypt requires as arguments the user's GitHub username and repository name.
@@ -29,6 +60,21 @@ def cli(username, repository, path, password, deploy, env, clipboard):
     is given as an argument, the encrypted password is added to the .travis.yml file.
     """
     key = retrieve_public_key('{}/{}' .format(username, repository))
+    if env_file:
+        if path:
+            config = load_travis_configuration(path)
+
+            for env_var, value in dotenv_values(env_file).items():
+                encrypted_env = encrypt_key(key, value.encode())
+                config.setdefault('env', {}).setdefault('global', {})[env_var] = {'secure': encrypted_env}
+            dump_travis_configuration(config, path)
+        else:
+            print('\nPlease add the following to your .travis.yml:')
+            for env_var, value in dotenv_values(env_file).items():
+                encrypted_env = encrypt_key(key, value.encode())
+                print("{}:\n  secure: {}".format(env_var, encrypted_env))
+        return
+
     encrypted_password = encrypt_key(key, password.encode())
 
     if path:

--- a/travis/cli.py
+++ b/travis/cli.py
@@ -66,6 +66,7 @@ def cli(username, repository, path, password, deploy, env, clipboard, env_file):
                 encrypted_env = encrypt_key(key, value.encode())
                 config.setdefault('env', {}).setdefault('global', {})[env_var] = {'secure': encrypted_env}
             dump_travis_configuration(config, path)
+            print('Encrypted variables from {} added to {}'.format(env_file, path))
         else:
             print('\nPlease add the following to your .travis.yml:')
             for env_var, value in dotenv_values(env_file).items():

--- a/travis/cli.py
+++ b/travis/cli.py
@@ -20,10 +20,7 @@ class NotRequiredIf(click.Option):
     def __init__(self, *args, **kwargs):
         self.not_required_if = kwargs.pop('not_required_if')
         assert self.not_required_if, "'not_required_if' parameter required"
-        kwargs['help'] = (kwargs.get('help', '') +
-            ' NOTE: This argument is mutually exclusive with %s' %
-            self.not_required_if
-        ).strip()
+        kwargs['help'] = (kwargs.get('help', '') + ' Mutually exclusive with %s' % self.not_required_if).strip()
         super(NotRequiredIf, self).__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx, opts, args):
@@ -33,23 +30,24 @@ class NotRequiredIf(click.Option):
         if other_present:
             if we_are_present:
                 raise click.UsageError(
-                    "Illegal usage: `%s` is mutually exclusive with `%s`" % (
-                        self.name, self.not_required_if))
+                    "Illegal usage: `%s` is mutually exclusive with `%s`" % (self.name, self.not_required_if))
             else:
                 self.prompt = None
 
-        return super(NotRequiredIf, self).handle_parse_result(
-            ctx, opts, args)
+        return super(NotRequiredIf, self).handle_parse_result(ctx, opts, args)
 
 @click.command()
 @click.argument('username')
 @click.argument('repository')
 @click.argument('path', type=click.Path(exists=True), required=False)
-@click.option('--password', cls=NotRequiredIf, not_required_if='env_file', prompt=True, hide_input=True, confirmation_prompt=False, help="The password to be encrypted.")
+@click.option('--password', cls=NotRequiredIf,
+              not_required_if='env_file', prompt=True,
+              hide_input=True, confirmation_prompt=False,
+              help="The password to be encrypted.")
 @click.option('--deploy', is_flag=True, help="Write to .travis.yml for deployment.")
 @click.option('--env', is_flag=True, help="Write to .travis.yml for environment variable use.")
 @click.option('--clipboard', is_flag=True, help="Copy the encrypted password to the clipboard")
-@click.option('--env-file', type=click.Path(exists=True))
+@click.option('--env-file', type=click.Path(exists=True), help='Path for a .env file containing variables to encrypt')
 def cli(username, repository, path, password, deploy, env, clipboard, env_file):
     """Encrypt passwords and environment variables for use with Travis CI.
 


### PR DESCRIPTION
This adds dotenv support! 🎉 

I'm not happy about how hard it was to suppress the password prompt, but there you have it.

So you can do

```
travis-encrypt org repo --env-file=my.env
```

And you should get something like

```
Please add the following to your .travis.yml:
REDIS_ADDRESS:
  secure: <ENCRYPTED STRING>
MEANING_OF_LIFE:
  secure: <ENCRYPTED STRING>
```

Specifying the yml path, it will add encrypted variables to the global env in the travis yml

Addresses #9 #6 